### PR TITLE
Adding potential fix for showing audio stats - depends on PR#13401

### DIFF
--- a/scripts/developer/utilities/audio/Stats.qml
+++ b/scripts/developer/utilities/audio/Stats.qml
@@ -25,7 +25,7 @@ Column {
 
         HifiControls.Button {
             id: toggleGraphs
-            property bool checked: false
+            checked: false
             anchors.horizontalCenter: parent.horizontalCenter
             text: checked ? "Hide graphs" : "Show graphs"
             onClicked: function() { checked = !checked; }

--- a/scripts/developer/utilities/audio/Stats.qml
+++ b/scripts/developer/utilities/audio/Stats.qml
@@ -12,7 +12,7 @@ import QtQuick 2.5
 import QtQuick.Controls 1.4
 import QtQuick.Layouts 1.3
 
-import "../../../../resources/qml/controls-uit" as HifiControls
+import controlsUit 1.0 as HifiControls
 
 Column {
     id: stats


### PR DESCRIPTION
this _should_ fix the issue described here: https://highfidelity.fogbugz.com/f/cases/13955/Audio-Stats-are-blank 

**TEST PLAN**
- Launch Interface
- Enable `Settings->Developer Menu`
- Open audio statistics via `Developer->Audio->Stats...`
- The popup window should display audio interface statistics